### PR TITLE
dp: pascal triangle

### DIFF
--- a/Java/algorithms/src/main/java/com/creations/algorithms/dp/pascal/Solution.java
+++ b/Java/algorithms/src/main/java/com/creations/algorithms/dp/pascal/Solution.java
@@ -1,0 +1,40 @@
+package com.creations.algorithms.dp.pascal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Problem: 118. Pascal's Triangle
+ *
+ * <p>URL: https://leetcode.com/problems/pascals-triangle/
+ *
+ * <p>Approaches
+ *
+ * <p>Each row can be built in a separate iteration.
+ *
+ * <p>The first item is added for each row, that means, 1 will be added in each row.
+ *
+ * <p>The last 1 is to be added only from the second row.
+ *
+ * <p>The middle elements are to be added only from the third row and will be the sum of 2 elements
+ * from the previous row which are same index and the prev index.
+ *
+ * <p>TC: O(n^2); SC: O(n^2)
+ */
+class Solution {
+  public List<List<Integer>> generate(int numRows) {
+    List<List<Integer>> res = new ArrayList<>();
+    for (int i = 0; i < numRows; i++) {
+      List<Integer> curr = new ArrayList<>();
+      curr.add(1);
+      for (int j = 1; j < i; j++) {
+        curr.add(res.get(i - 1).get(j) + res.get(i - 1).get(j - 1));
+      }
+      if (i > 0) {
+        curr.add(1);
+      }
+      res.add(curr);
+    }
+    return res;
+  }
+}

--- a/Java/algorithms/src/test/java/com/creations/algorithms/dp/pascal/SolutionTest.java
+++ b/Java/algorithms/src/test/java/com/creations/algorithms/dp/pascal/SolutionTest.java
@@ -1,0 +1,24 @@
+package com.creations.algorithms.dp.pascal;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SolutionTest {
+
+  private static Stream<Arguments> arguments() {
+    return Stream.of(
+        Arguments.of(3, List.of(List.of(1), List.of(1, 1), List.of(1, 2, 1))),
+        Arguments.of(4, List.of(List.of(1), List.of(1, 1), List.of(1, 2, 1), List.of(1, 3, 3, 1))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("arguments")
+  public void test(int n, List<List<Integer>> expected) {
+    List<List<Integer>> generate = new Solution().generate(n);
+    Assertions.assertIterableEquals(expected, generate);
+  }
+}


### PR DESCRIPTION
# Problem

Given an integer numRows, return the first numRows of Pascal's triangle.

In Pascal's triangle, each number is the sum of the two numbers directly above it as shown:

## Constraints

1 <= numRows <= 30

## Input

Input: numRows = 5

## Output

Output: [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]

## Approach

Each row can be built in a separate iteration.
The first item is added for each row, that means, 1 will be added in each row.
The last 1 is to be added only from the second row.
The middle elements are to be added only from the third row and will be the sum of 2 elements from the previous row which are same index and the prev index.

## TC

O(n^2)

## SC

O(n^2)